### PR TITLE
fix: width and height from container

### DIFF
--- a/src/components/ModalWindow/index.module.scss
+++ b/src/components/ModalWindow/index.module.scss
@@ -1,15 +1,14 @@
 @import "../styles/foundation.scss";
 
 .container {
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  width: 100vw;
+  height: 100vh;
+  position:fixed;
+  top: 0; left: 0; bottom: 0; right: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: red;
-
+  
   &.invisible {
     .blur {
       display: none;


### PR DESCRIPTION
Now the container of the modal window is stretched not to the height of the page, but to the height of the screen