### PR TITLE
fix:'display: none;' added to the class container.

### DIFF
--- a/src/components/ModalWindow/index.module.scss
+++ b/src/components/ModalWindow/index.module.scss
@@ -3,19 +3,17 @@
 .container {
   width: 100vw;
   height: 100vh;
-  position:fixed;
-  top: 0; left: 0; bottom: 0; right: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   &.invisible {
-    .blur {
-      display: none;
-    }
-    .modalWindow {
-      display: none;
-    }
+    display: none;
   }
 
   .blur {
@@ -58,7 +56,7 @@
       width: 364px;
       text-align: center;
       letter-spacing: 0.001em;
-      
+
       .header {
         @extend .H6;
         margin-bottom: 8px;


### PR DESCRIPTION
Fixed a bug when disabling a modal window: an invisible component container stretched to full screen did not allow interacting with page elements.