### PR TITLE
fix: removing the event listener

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -48,11 +48,12 @@ export const MetTooltip: FC<MetTooltipProps> = ({
   }
 
   useEffect(() => {
-    wrapperRef.current.addEventListener("mouseenter", handleHover);
-    wrapperRef.current.addEventListener("mouseleave", handleHover);
+    const container = wrapperRef.current;
+    container.addEventListener("mouseenter", handleHover);
+    container.addEventListener("mouseleave", handleHover);
     return () => {
-      wrapperRef.current.removeEventListener("mouseenter", handleHover);
-      wrapperRef.current.removeEventListener("mouseleave", handleHover);
+      container.removeEventListener("mouseenter", handleHover);
+      container.removeEventListener("mouseleave", handleHover);
     };
   }, []);
 


### PR DESCRIPTION
A variable has been added to hold the container element (ref.current). The problem with Virtual DOM has been fixed.